### PR TITLE
feat: redesign HomeScreen in Windows 2000 style

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,47 +48,210 @@ const BootScreen = ({ onComplete }) => {
 const HomeScreen = ({ onUpload, onNavigate }) => {
   const timeStr = useSystemClock();
   return (
-    <div className="home-layer">
-      <div className="home-grid" />
-      <div className="hero-content" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '24px' }}>
-        
-        <div className="system-status" style={{ marginBottom: '10px', background: 'rgba(255, 184, 0, 0.05)', border: '1px solid rgba(255, 184, 0, 0.2)', padding: '6px 12px', borderRadius: '4px' }}>
-            <div className="status-dot"/>
-            SYSTEM_READY 
-            <span style={{ margin: '0 12px', opacity: 0.3, color: '#fff' }}>|</span> 
-            <span style={{ color: 'var(--text-muted)' }}>{timeStr}</span>
-        </div>
-
-        <div className="hero-block" style={{ margin: '0', animation: 'lens-focus 1.5s cubic-bezier(0.19, 1, 0.22, 1) backwards' }}>
-          <img src="/lf_orange.png" alt="LUMAFORGE" style={{ height: '140px', objectFit: 'contain', filter: 'drop-shadow(0 0 50px rgba(255, 184, 0, 0.15))' }} />
-        </div>
-
-        <div className="hero-tag" style={{ letterSpacing: '6px', color: '#888', margin: '0', animation: 'fade-up 1s ease-out 0.2s backwards' }}>
-            PROFESSIONAL OPTICS ENGINE
-        </div>
-
-        <div className="start-btn-group" style={{ marginTop: '15px', animation: 'fade-up 1s ease-out 0.4s backwards' }}>
-          <button className="btn-tech primary" onClick={() => document.getElementById('home-upload').click()} style={{ padding: '16px 40px', fontSize: '12px', letterSpacing: '1px' }}>
-              OPEN SOURCE FILE
-          </button>
-        </div>
-        <input id="home-upload" type="file" hidden onChange={onUpload} accept="image/*,.cube" />
-
-        <div className="home-nav-links" style={{ display: 'flex', gap: '20px', marginTop: '30px', animation: 'fade-up 1s ease-out 0.6s backwards' }}>
-          <button className="text-nav-btn" onClick={() => onNavigate('BOOT_TO_UPLINK')}>[ THE UPLINK FEED ]</button>
-          <button className="text-nav-btn" onClick={() => onNavigate('BOOT_TO_DIAGNOSTICS')}>[ SYSTEM DIAGNOSTICS ]</button>
-          <button className="text-nav-btn" onClick={() => onNavigate('BOOT_TO_MANUAL')}>[ OPTICS MANUAL ]</button>
-        </div>
-
+    <div className="win2k-desktop">
+      {/* Desktop Icons */}
+      <div className="win2k-desktop-icons">
+        <button className="win2k-icon" onClick={() => document.getElementById('home-upload').click()}>
+          <div className="win2k-icon-img">
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none"><rect x="3" y="5" width="22" height="26" rx="1" fill="#fff" stroke="#999" strokeWidth="1"/><rect x="3" y="5" width="22" height="6" rx="1" fill="#1550a0"/><rect x="6" y="14" width="16" height="2" rx="1" fill="#ccc"/><rect x="6" y="18" width="12" height="2" rx="1" fill="#ccc"/><rect x="6" y="22" width="14" height="2" rx="1" fill="#ccc"/><circle cx="25" cy="25" r="7" fill="#ffd700" stroke="#b8860b" strokeWidth="1.5"/><path d="M25 22v6M22 25h6" stroke="#b8860b" strokeWidth="2" strokeLinecap="round"/></svg>
+          </div>
+          <span>Open Image</span>
+        </button>
+        <button className="win2k-icon" onClick={() => onNavigate('BOOT_TO_UPLINK')}>
+          <div className="win2k-icon-img">
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none"><circle cx="16" cy="16" r="12" fill="#1550a0" stroke="#0a2b70" strokeWidth="1.5"/><ellipse cx="16" cy="16" rx="5" ry="12" stroke="#6ab0ff" strokeWidth="1" fill="none"/><line x1="4" y1="16" x2="28" y2="16" stroke="#6ab0ff" strokeWidth="1"/><line x1="6" y1="10" x2="26" y2="10" stroke="#6ab0ff" strokeWidth="1"/><line x1="6" y1="22" x2="26" y2="22" stroke="#6ab0ff" strokeWidth="1"/></svg>
+          </div>
+          <span>Uplink Feed</span>
+        </button>
+        <button className="win2k-icon" onClick={() => onNavigate('BOOT_TO_DIAGNOSTICS')}>
+          <div className="win2k-icon-img">
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none"><rect x="4" y="6" width="24" height="18" rx="2" fill="#c0c0c0" stroke="#808080" strokeWidth="1.5"/><rect x="6" y="8" width="20" height="14" fill="#000080"/><polyline points="8,18 12,12 16,15 20,10 24,14" stroke="#00ff00" strokeWidth="1.5" fill="none"/><rect x="10" y="24" width="12" height="3" fill="#808080"/><rect x="8" y="27" width="16" height="2" fill="#a0a0a0"/></svg>
+          </div>
+          <span>Diagnostics</span>
+        </button>
+        <button className="win2k-icon" onClick={() => onNavigate('BOOT_TO_MANUAL')}>
+          <div className="win2k-icon-img">
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none"><rect x="6" y="3" width="18" height="24" rx="1" fill="#fff9e0" stroke="#a08000" strokeWidth="1.5"/><rect x="6" y="3" width="18" height="5" fill="#ffd700" rx="1"/><rect x="9" y="11" width="12" height="1.5" rx="1" fill="#888"/><rect x="9" y="14.5" width="10" height="1.5" rx="1" fill="#888"/><rect x="9" y="18" width="12" height="1.5" rx="1" fill="#888"/><rect x="9" y="21.5" width="8" height="1.5" rx="1" fill="#888"/></svg>
+          </div>
+          <span>Optics Manual</span>
+        </button>
       </div>
 
-      <div className="home-footer">
-        <div className="footer-row"><span>© 2026 LUMAFORGE</span><span className="footer-divider">|</span><span>BUILD v1.3.0</span></div>
-        <div className="footer-row links">
-           <span style={{color: '#fff'}}>CREATOR: SAUMYA GANESHE</span>
-           <a href="https://github.com/sganeshe" target="_blank" rel="noreferrer">[ GITHUB ]</a>
-           <a href="https://www.linkedin.com/in/saumyaganeshe/" target="_blank" rel="noreferrer">[ LINKEDIN ]</a>
-           <a href="https://sganeshe.live/" target="_blank" rel="noreferrer">[ PORTFOLIO ]</a>
+      {/* Central Window */}
+      <div className="win2k-window win2k-main-window">
+        {/* Title Bar */}
+        <div className="win2k-titlebar">
+          <div className="win2k-titlebar-left">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="1" y="1" width="14" height="14" rx="1" fill="#ffd700"/><path d="M4 8 L8 4 L12 8 L8 12 Z" fill="#b8860b"/></svg>
+            <span>LumaForge - Professional Optics Engine</span>
+          </div>
+          <div className="win2k-titlebar-btns">
+            <button className="win2k-tb-btn win2k-min">_</button>
+            <button className="win2k-tb-btn win2k-max">□</button>
+            <button className="win2k-tb-btn win2k-close">✕</button>
+          </div>
+        </div>
+
+        {/* Menu Bar */}
+        <div className="win2k-menubar">
+          <span className="win2k-menu-item"><u>F</u>ile</span>
+          <span className="win2k-menu-item"><u>E</u>dit</span>
+          <span className="win2k-menu-item"><u>V</u>iew</span>
+          <span className="win2k-menu-item"><u>T</u>ools</span>
+          <span className="win2k-menu-item"><u>H</u>elp</span>
+        </div>
+
+        {/* Toolbar */}
+        <div className="win2k-toolbar">
+          <button className="win2k-toolbar-btn" onClick={() => document.getElementById('home-upload').click()}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="1" y="3" width="10" height="12" rx="1" fill="#fff" stroke="#666" strokeWidth="1"/><rect x="1" y="3" width="10" height="4" fill="#1550a0"/><path d="M8 1 L15 1 L15 8 L11 12 L8 12 Z" fill="#fffbe0" stroke="#666" strokeWidth="1"/><path d="M11 1 L11 8 L15 8" stroke="#666" strokeWidth="1" fill="none"/></svg>
+            Open
+          </button>
+          <div className="win2k-toolbar-sep"/>
+          <button className="win2k-toolbar-btn" onClick={() => onNavigate('BOOT_TO_UPLINK')}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" fill="#1550a0" stroke="#0a2b70"/><ellipse cx="8" cy="8" rx="2.5" ry="6" stroke="#6ab0ff" strokeWidth="0.8" fill="none"/><line x1="2" y1="8" x2="14" y2="8" stroke="#6ab0ff" strokeWidth="0.8"/></svg>
+            Uplink
+          </button>
+          <button className="win2k-toolbar-btn" onClick={() => onNavigate('BOOT_TO_DIAGNOSTICS')}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="2" y="3" width="12" height="9" rx="1" fill="#000080" stroke="#666"/><polyline points="4,10 6,7 8,8.5 10,5.5 12,7.5" stroke="#00ff00" strokeWidth="1" fill="none"/></svg>
+            Diagnostics
+          </button>
+          <button className="win2k-toolbar-btn" onClick={() => onNavigate('BOOT_TO_MANUAL')}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="3" y="1" width="10" height="14" rx="1" fill="#fffbe0" stroke="#a08000"/><rect x="3" y="1" width="10" height="3" fill="#ffd700"/><rect x="5" y="7" width="6" height="1" rx="0.5" fill="#888"/><rect x="5" y="9" width="5" height="1" rx="0.5" fill="#888"/><rect x="5" y="11" width="6" height="1" rx="0.5" fill="#888"/></svg>
+            Manual
+          </button>
+        </div>
+
+        {/* Content Area */}
+        <div className="win2k-content">
+          {/* Left Panel */}
+          <div className="win2k-side-panel">
+            <div className="win2k-panel-header">Quick Launch</div>
+            <div className="win2k-panel-items">
+              <button className="win2k-panel-item" onClick={() => document.getElementById('home-upload').click()}>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="1" y="2" width="10" height="12" rx="1" fill="#fff" stroke="#666"/><rect x="1" y="2" width="10" height="4" fill="#1550a0"/><circle cx="12" cy="12" r="4" fill="#ffd700" stroke="#b8860b"/><path d="M12 10v4M10 12h4" stroke="#b8860b" strokeWidth="1.2" strokeLinecap="round"/></svg>
+                Open Image File
+              </button>
+              <button className="win2k-panel-item" onClick={() => onNavigate('BOOT_TO_UPLINK')}>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" fill="#1550a0" stroke="#0a2b70"/><ellipse cx="8" cy="8" rx="2.5" ry="6" stroke="#6ab0ff" strokeWidth="0.8" fill="none"/></svg>
+                The Uplink Feed
+              </button>
+              <button className="win2k-panel-item" onClick={() => onNavigate('BOOT_TO_DIAGNOSTICS')}>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="2" y="3" width="12" height="9" rx="1" fill="#000080" stroke="#666"/><polyline points="4,10 6,7 8,8.5 10,5.5 12,7.5" stroke="#00ff00" strokeWidth="1"/></svg>
+                System Diagnostics
+              </button>
+              <button className="win2k-panel-item" onClick={() => onNavigate('BOOT_TO_MANUAL')}>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="3" y="1" width="10" height="14" rx="1" fill="#fffbe0" stroke="#a08000"/><rect x="3" y="1" width="10" height="3" fill="#ffd700"/><rect x="5" y="7" width="6" height="1" rx="0.5" fill="#888"/></svg>
+                Optics Manual
+              </button>
+            </div>
+            <div className="win2k-panel-header" style={{marginTop: '16px'}}>About</div>
+            <div className="win2k-panel-about">
+              <p>LumaForge v1.3.0</p>
+              <p>Professional photo editing and color grading engine.</p>
+              <p style={{marginTop:'8px', color:'#000080'}}>© 2026 LumaForge</p>
+              <p>Creator: Saumya Ganeshe</p>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="win2k-panel-divider"/>
+
+          {/* Main Content */}
+          <div className="win2k-main-content">
+            <div className="win2k-logo-area">
+              <img src="/lf_orange.png" alt="LUMAFORGE" style={{ height: '90px', objectFit: 'contain' }} />
+              <div className="win2k-app-title">LUMAFORGE</div>
+              <div className="win2k-app-subtitle">Professional Optics Engine — Build v1.3.0</div>
+            </div>
+
+            <div className="win2k-status-bar-inner">
+              <div className="win2k-led"/>
+              <span>System Ready</span>
+              <span className="win2k-status-sep">|</span>
+              <span>{timeStr}</span>
+            </div>
+
+            <div className="win2k-action-area">
+              <button className="win2k-btn win2k-btn-primary" onClick={() => document.getElementById('home-upload').click()}>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M2 11 L8 5 L14 11" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/><rect x="5" y="10" width="6" height="4" rx="0.5" fill="none" stroke="currentColor" strokeWidth="1.5"/></svg>
+                Open Source File...
+              </button>
+              <input id="home-upload" type="file" hidden onChange={onUpload} accept="image/*,.cube" />
+              <button className="win2k-btn" onClick={() => onNavigate('BOOT_TO_UPLINK')}>Browse Uplink Feed</button>
+            </div>
+
+            <div className="win2k-feature-grid">
+              <div className="win2k-feature-item">
+                <div className="win2k-feature-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" fill="#e0ecff" stroke="#1550a0" strokeWidth="1.5"/><path d="M8 12 L11 15 L16 9" stroke="#1550a0" strokeWidth="2" strokeLinecap="round"/></svg>
+                </div>
+                <div className="win2k-feature-text">
+                  <strong>Color Grading</strong>
+                  <span>Professional LUT support</span>
+                </div>
+              </div>
+              <div className="win2k-feature-item">
+                <div className="win2k-feature-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" fill="#fff9e0" stroke="#a08000" strokeWidth="1.5"/><polyline points="5,17 9,11 12,14 15,8 19,12" stroke="#a08000" strokeWidth="1.5" fill="none"/></svg>
+                </div>
+                <div className="win2k-feature-text">
+                  <strong>Curves Editor</strong>
+                  <span>Advanced tone mapping</span>
+                </div>
+              </div>
+              <div className="win2k-feature-item">
+                <div className="win2k-feature-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" fill="#e8ffe8" stroke="#2a7a2a" strokeWidth="1.5"/><circle cx="12" cy="12" r="4" fill="none" stroke="#2a7a2a" strokeWidth="1.5"/><line x1="12" y1="3" x2="12" y2="7" stroke="#2a7a2a" strokeWidth="1.5"/><line x1="12" y1="17" x2="12" y2="21" stroke="#2a7a2a" strokeWidth="1.5"/><line x1="3" y1="12" x2="7" y2="12" stroke="#2a7a2a" strokeWidth="1.5"/><line x1="17" y1="12" x2="21" y2="12" stroke="#2a7a2a" strokeWidth="1.5"/></svg>
+                </div>
+                <div className="win2k-feature-text">
+                  <strong>AI Masking</strong>
+                  <span>Intelligent selection tools</span>
+                </div>
+              </div>
+              <div className="win2k-feature-item">
+                <div className="win2k-feature-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" fill="#f0e8ff" stroke="#6020a0" strokeWidth="1.5"/><path d="M7 17 L10 10 L13 14 L15 11 L17 17" stroke="#6020a0" strokeWidth="1.5" strokeLinecap="round" fill="none"/></svg>
+                </div>
+                <div className="win2k-feature-text">
+                  <strong>Cloud Presets</strong>
+                  <span>Save and sync your grades</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Status Bar */}
+        <div className="win2k-statusbar">
+          <div className="win2k-statusbar-section">Ready</div>
+          <div className="win2k-statusbar-section">v1.3.0</div>
+          <div className="win2k-statusbar-section">
+            <a href="https://github.com/sganeshe" target="_blank" rel="noreferrer" className="win2k-link">GitHub</a>
+            {' | '}
+            <a href="https://www.linkedin.com/in/saumyaganeshe/" target="_blank" rel="noreferrer" className="win2k-link">LinkedIn</a>
+            {' | '}
+            <a href="https://sganeshe.live/" target="_blank" rel="noreferrer" className="win2k-link">Portfolio</a>
+          </div>
+        </div>
+      </div>
+
+      {/* Taskbar */}
+      <div className="win2k-taskbar">
+        <button className="win2k-start-btn">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect width="16" height="16" fill="#1550a0"/><rect x="1" y="1" width="6" height="6" fill="#f00"/><rect x="9" y="1" width="6" height="6" fill="#0f0"/><rect x="1" y="9" width="6" height="6" fill="#00f"/><rect x="9" y="9" width="6" height="6" fill="#ff0"/></svg>
+          <strong>Start</strong>
+        </button>
+        <div className="win2k-taskbar-sep"/>
+        <div className="win2k-active-window">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="1" y="1" width="10" height="10" rx="1" fill="#ffd700"/><path d="M3 6 L6 3 L9 6 L6 9 Z" fill="#b8860b"/></svg>
+          LumaForge - Professional Optics Engine
+        </div>
+        <div style={{flex: 1}}/>
+        <div className="win2k-tray">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="2" y="5" width="12" height="8" rx="1" fill="#c0c0c0" stroke="#808080"/><path d="M5 5 V3 Q8 1 11 3 V5" fill="#c0c0c0" stroke="#808080"/></svg>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="2" y="6" width="6" height="6" rx="0.5" fill="#1550a0"/><rect x="10" y="8" width="4" height="2" rx="0.5" fill="#aaa"/><rect x="10" y="4" width="4" height="2" rx="0.5" fill="#aaa"/><rect x="10" y="12" width="4" height="2" rx="0.5" fill="#aaa"/></svg>
+          <span className="win2k-clock">{timeStr}</span>
         </div>
       </div>
     </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -450,6 +450,475 @@ input[type=range]::-webkit-slider-thumb:hover { transform: scale(1.3); backgroun
 .text-nav-btn:hover { color: #fff; text-shadow: 0 0 10px rgba(255,255,255,0.5); }
 
 /* =========================================================================
+   WIN2K / WINDOWS 2000 HOME SCREEN
+   ========================================================================= */
+
+/* Mixins as CSS custom properties for bevel borders */
+:root {
+  --win2k-raised: inset -1px -1px 0 #808080, inset 1px 1px 0 #ffffff, inset -2px -2px 0 #404040, inset 2px 2px 0 #dfdfdf;
+  --win2k-sunken: inset 1px 1px 0 #808080, inset -1px -1px 0 #ffffff, inset 2px 2px 0 #404040, inset -2px -2px 0 #dfdfdf;
+  --win2k-bg: #d4d0c8;
+  --win2k-blue: #0a246a;
+  --win2k-title-grad: linear-gradient(to right, #0a246a, #a6caf0);
+  --win2k-font: 'Tahoma', 'Verdana', 'MS Sans Serif', sans-serif;
+}
+
+.win2k-desktop {
+  position: fixed;
+  inset: 0;
+  background: #3a6ea5 url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAGklEQVQImWNgYGD4z8BQDwAEgAF/QualIQAAAABJRU5ErkJggg==") repeat;
+  background-color: #3a6ea5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--win2k-font);
+  z-index: 100;
+  padding-bottom: 28px;
+}
+
+/* Desktop icons column */
+.win2k-desktop-icons {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.win2k-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  width: 72px;
+  color: #fff;
+  font-family: var(--win2k-font);
+  font-size: 11px;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.9);
+  text-align: center;
+  border-radius: 2px;
+}
+.win2k-icon:hover { background: rgba(255,255,255,0.15); outline: 1px dotted rgba(255,255,255,0.6); }
+.win2k-icon:focus { outline: 1px dotted #fff; background: rgba(0,100,200,0.4); }
+.win2k-icon-img {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.win2k-icon span { line-height: 1.2; word-break: break-word; }
+
+/* Main Window */
+.win2k-main-window {
+  width: min(960px, calc(100vw - 40px));
+  max-height: calc(100vh - 56px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 2px 2px 8px rgba(0,0,0,0.5), var(--win2k-raised);
+  background: var(--win2k-bg);
+}
+
+/* Title bar */
+.win2k-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--win2k-title-grad);
+  padding: 3px 4px 3px 6px;
+  height: 24px;
+  flex-shrink: 0;
+  user-select: none;
+}
+.win2k-titlebar-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  font-family: var(--win2k-font);
+  text-shadow: 1px 1px 0 rgba(0,0,0,0.4);
+  overflow: hidden;
+  white-space: nowrap;
+}
+.win2k-titlebar-btns {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.win2k-tb-btn {
+  width: 16px;
+  height: 14px;
+  font-size: 9px;
+  font-family: var(--win2k-font);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  line-height: 1;
+  box-shadow: var(--win2k-raised);
+  background: var(--win2k-bg);
+  color: #000;
+}
+.win2k-tb-btn:hover { background: #e0e0d8; }
+.win2k-tb-btn:active { box-shadow: var(--win2k-sunken); }
+.win2k-close { background: var(--win2k-bg); }
+
+/* Menu bar */
+.win2k-menubar {
+  display: flex;
+  gap: 0;
+  padding: 2px 4px;
+  background: var(--win2k-bg);
+  border-bottom: 1px solid #808080;
+  flex-shrink: 0;
+}
+.win2k-menu-item {
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  color: #000;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+.win2k-menu-item:hover { background: #0a246a; color: #fff; }
+
+/* Toolbar */
+.win2k-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px 6px;
+  background: var(--win2k-bg);
+  border-bottom: 1px solid #808080;
+  flex-shrink: 0;
+}
+.win2k-toolbar-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  background: var(--win2k-bg);
+  border: none;
+  cursor: pointer;
+  color: #000;
+  box-shadow: var(--win2k-raised);
+}
+.win2k-toolbar-btn:hover { background: #e8e4dc; }
+.win2k-toolbar-btn:active { box-shadow: var(--win2k-sunken); }
+.win2k-toolbar-sep {
+  width: 1px;
+  height: 22px;
+  background: #808080;
+  box-shadow: 1px 0 0 #fff;
+  margin: 0 4px;
+}
+
+/* Content area layout */
+.win2k-content {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Left side panel (like Windows Explorer) */
+.win2k-side-panel {
+  width: 180px;
+  flex-shrink: 0;
+  background: #e8e4da;
+  border-right: 1px solid #808080;
+  box-shadow: inset -2px 0 0 #fff;
+  padding: 10px 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.win2k-panel-header {
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  font-weight: bold;
+  color: #fff;
+  background: #0a246a;
+  padding: 3px 10px;
+  margin-bottom: 4px;
+}
+.win2k-panel-items {
+  display: flex;
+  flex-direction: column;
+  padding: 0 4px;
+  gap: 1px;
+}
+.win2k-panel-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  color: #000080;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline;
+  border-radius: 0;
+}
+.win2k-panel-item:hover { background: #c8e4ff; color: #000; }
+.win2k-panel-about {
+  padding: 6px 10px;
+  font-size: 10px;
+  font-family: var(--win2k-font);
+  color: #444;
+  line-height: 1.5;
+}
+.win2k-panel-about p { margin: 0 0 4px 0; }
+
+.win2k-panel-divider {
+  width: 1px;
+  background: #808080;
+  box-shadow: 1px 0 0 #fff;
+  flex-shrink: 0;
+}
+
+/* Main right content */
+.win2k-main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 28px;
+  overflow-y: auto;
+  background: var(--win2k-bg);
+  gap: 16px;
+}
+
+.win2k-logo-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 16px;
+  background: #fff;
+  box-shadow: var(--win2k-sunken);
+  border-radius: 0;
+}
+.win2k-app-title {
+  font-size: 22px;
+  font-weight: bold;
+  font-family: var(--win2k-font);
+  color: #0a246a;
+  margin-top: 8px;
+  letter-spacing: 3px;
+}
+.win2k-app-subtitle {
+  font-size: 11px;
+  color: #666;
+  font-family: var(--win2k-font);
+  margin-top: 4px;
+}
+
+.win2k-status-bar-inner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  color: #444;
+  background: #fff;
+  border: 1px solid #999;
+  box-shadow: var(--win2k-sunken);
+  padding: 4px 10px;
+}
+.win2k-led {
+  width: 8px;
+  height: 8px;
+  background: #00cc00;
+  border-radius: 50%;
+  border: 1px solid #008800;
+  box-shadow: 0 0 4px #00ff00;
+  flex-shrink: 0;
+}
+.win2k-status-sep { color: #ccc; margin: 0 4px; }
+
+.win2k-action-area {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+/* Classic Win2K buttons */
+.win2k-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 18px;
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  background: var(--win2k-bg);
+  color: #000;
+  border: none;
+  cursor: pointer;
+  min-width: 100px;
+  box-shadow: var(--win2k-raised);
+}
+.win2k-btn:hover { background: #e8e4dc; }
+.win2k-btn:active { box-shadow: var(--win2k-sunken); padding: 7px 17px 5px 19px; }
+.win2k-btn-primary {
+  background: #d4d0c8;
+  font-weight: bold;
+}
+.win2k-btn-primary:hover { background: #e8e4d0; }
+
+/* Feature grid */
+.win2k-feature-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 4px;
+}
+.win2k-feature-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  padding: 10px 12px;
+  box-shadow: var(--win2k-sunken);
+}
+.win2k-feature-icon { flex-shrink: 0; }
+.win2k-feature-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: var(--win2k-font);
+}
+.win2k-feature-text strong { font-size: 11px; color: #000; }
+.win2k-feature-text span { font-size: 10px; color: #666; }
+
+/* Status bar at bottom of window */
+.win2k-statusbar {
+  display: flex;
+  align-items: center;
+  border-top: 1px solid #808080;
+  box-shadow: inset 0 1px 0 #fff;
+  background: var(--win2k-bg);
+  padding: 2px 4px;
+  gap: 0;
+  flex-shrink: 0;
+}
+.win2k-statusbar-section {
+  font-size: 10px;
+  font-family: var(--win2k-font);
+  color: #444;
+  padding: 2px 8px;
+  border-right: 1px solid #808080;
+  box-shadow: inset -1px 0 0 #fff;
+  white-space: nowrap;
+}
+.win2k-statusbar-section:last-child { border-right: none; box-shadow: none; }
+.win2k-link {
+  color: #000080;
+  text-decoration: none;
+  font-size: 10px;
+}
+.win2k-link:hover { text-decoration: underline; color: #0000ff; }
+
+/* Taskbar */
+.win2k-taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 28px;
+  background: var(--win2k-bg);
+  border-top: 2px solid #fff;
+  box-shadow: inset 0 1px 0 #fff, 0 -1px 0 #808080;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  z-index: 200;
+}
+.win2k-start-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 10px 0 6px;
+  font-size: 12px;
+  font-family: var(--win2k-font);
+  background: var(--win2k-bg);
+  color: #000;
+  border: none;
+  cursor: pointer;
+  box-shadow: var(--win2k-raised);
+}
+.win2k-start-btn:hover { background: #e0dccc; }
+.win2k-start-btn:active { box-shadow: var(--win2k-sunken); }
+.win2k-taskbar-sep {
+  width: 1px;
+  height: 20px;
+  background: #808080;
+  box-shadow: 1px 0 0 #fff;
+  margin: 0 4px;
+}
+.win2k-active-window {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 10px;
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  background: #c0bcb4;
+  color: #000;
+  box-shadow: var(--win2k-sunken);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+.win2k-tray {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 8px;
+  background: #c8c4bc;
+  box-shadow: var(--win2k-sunken);
+  border-radius: 0;
+}
+.win2k-clock {
+  font-size: 11px;
+  font-family: var(--win2k-font);
+  color: #000;
+  min-width: 50px;
+  text-align: center;
+}
+
+/* Mobile adaptations for Win2K */
+@media screen and (max-width: 700px) {
+  .win2k-desktop-icons { display: none; }
+  .win2k-side-panel { display: none; }
+  .win2k-panel-divider { display: none; }
+  .win2k-main-content { padding: 12px; }
+  .win2k-feature-grid { grid-template-columns: 1fr; }
+  .win2k-active-window { max-width: 180px; font-size: 10px; }
+  .win2k-toolbar-btn span { display: none; }
+  .win2k-logo-area img { height: 60px !important; }
+  .win2k-app-title { font-size: 16px; }
+}
+
+/* =========================================================================
    GEOMETRY & CROP HANDLES (DESKTOP)
    ========================================================================= */
 .crop-handle {


### PR DESCRIPTION
Redesigns the LUMAFORGE home screen to mimic the classic Microsoft Windows 2000 UI aesthetic.

## Changes

### src/App.jsx
- Replaced the dark sci-fi HomeScreen JSX with a Win2K-style layout featuring:
  - A blue tiled desktop background with left-rail desktop icons
  - A centred application window with gradient blue title bar, menu bar, and toolbar
  - An Explorer-style left sidebar panel with quick-launch links and app info
  - Main content area with logo, system-ready status indicator, action buttons, and a 2x2 feature grid
  - Classic Win2K status bar and a full taskbar with Start button, active-window chip, system tray icons, and live clock

### src/styles/index.css
- Added a large Win2K CSS section with raised/sunken bevel box-shadows
- Styles for all Win2K window chrome, sidebar, status bar, and taskbar elements
- Responsive mobile overrides that collapse the side panel and desktop icons on narrow viewports